### PR TITLE
fix: (src/index.js) 添加源出错后 144行报错对象变量名不一致导致的错误

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ program.command('add').description('自定义镜像').action(() => {
             fs.writeFileSync(path.join(__dirname, '../registries.json'), JSON.stringify(registries, null, 4))
             console.log(chalk.blue('添加完成'))
         }
-        catch (e) {
+        catch (err) {
             console.log(chalk.red(err))
         }
 


### PR DESCRIPTION
当添加三方源出错后，的报错对象变量名写的不一致（144行），导致报错信息也报错的修复。